### PR TITLE
[Feature] Added drawing and pseudo code parser for Switch block

### DIFF
--- a/src/elements.typ
+++ b/src/elements.typ
@@ -60,10 +60,12 @@
   ..args.named()
 )
 
-#let switch( text, ..branches-args ) = element(TYPES.SWITCH,
+#let switch( text, branches, ..args ) = element(TYPES.SWITCH,
   text,
-  brnaches: branches-args.pos(),
-  ..branches-args.named()
+  column-split: (branches.len() - 1) / branches.len(),
+  branches: branches,
+  labels: (),
+  ..args.named()
 )
 
 #let parallel( text, ..branches-args ) = element(TYPES.PARALLEL,

--- a/src/nassi.typ
+++ b/src/nassi.typ
@@ -59,6 +59,49 @@
           50%
         },
       )
+    } else if line.starts-with("switch ") {
+      let branches = (:)
+      let default = ()
+      let default-branch = false
+      let switch-count = 0
+
+      i += 1
+      while switch-count > 0 or code.at(i).trim() not in ("endswitch", "end switch") {
+        let code-line = code.at(i).trim()
+
+        if switch-count > 0 and code-line in ("endswitch", "end switch") {
+          switch-count -= 1
+        }
+
+        if code-line.starts-with("case ") and switch-count == 0 {
+          default-branch = false
+          let key = code-line.slice("case ".len())
+          branches.insert(key, ())
+        } else if code-line.starts-with("default") and switch-count == 0 {
+          default-branch = true
+        } else if branches.len() > 0 or default-branch {
+          if code-line.starts-with("switch") {
+            switch-count += 1
+          } 
+          if default-branch {
+            default += (code.at(i),)
+          } else {
+            branches.at(branches.keys().at(-1)) += (code.at(i),)
+          }
+        }
+
+        i += 1
+      }
+
+      for (key, value) in branches {
+        branches.at(key) = parse(value.join("\n"))
+      }
+      branches.default = parse(default.join("\n"))
+
+      elems += elements.switch(
+        line.slice("switch ".len()).trim(),
+        branches
+      )
     } else if line.starts-with("while ") {
       let children = ()
       let while-count = 0


### PR DESCRIPTION
# What

This Pull Request adds the `switch` function which draws a switch block with a condition and multiple branches in addition to a default branch. The `switch` function can also be used by writing a switch statement in pseudo code. 

![grafik](https://github.com/user-attachments/assets/d5f66faa-720b-4b7e-9ffe-f0bc75aa4685)

# Why

Switch blocks are an essential part of Nassi-Shneiderman Diagrams. Their absence prevented me using this typst package in one of my documents, prompting me to implement this feature my self. 

# How

I used the stub that was already present in `elements.typ`. The parts in `draw.typ` and `nassi.typ` are inspired by the mechanisms used for `branch`. 

It took some time to understand how the parser works but I got it working in the end. I tried to copy the approach used by the other statements (though I probably would have implemented it differently). 

The hardest part for drawing was calculating the hight of the lines going down from the triangle containing the condition. It works after I solved the first statement of the Intercept theorem for the height. 

# Usage

Using the `switch` function

```typst
#nassi.diagram({
import nassi.elements: *

switch("trafficLight", (
    red: {
      process("pressBrakes()")
      assign("Ignission", "off")
    },
    yellow: {
      assign("Ignission", "on")
    },
    green: {
      process("accelerate()")
    },
    default: {}
  ))
})
```

Using the pseudo code

```typst
switch trafficLight
  case red
    pressBrakes()
    Ignission <- off
  case yellow
    Ignission <- on
  case green
    accelerate()
  default
end switch
```